### PR TITLE
Make parameters optional (except for output-directory)

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-slather coverage --llvm-cov --output-directory "llvm-cov" --binary-basename "$binary_basename" --workspace "$workspace" --scheme "$scheme" "$project"
+slather coverage --llvm-cov --output-directory "llvm-cov" ${binary_basename:+--binary-basename "$binary-basename"} ${workspace:+--workspace "$workspace"} ${scheme:+--scheme "$scheme"} ${project:+"$project"}
 mv llvm-cov/report.llcov $BITRISE_DEPLOY_DIR
 
 curl -X "POST" "https://$gitpub_sonar_bridge_host/rest/api/1.0/projects/$gitpub_sonar_bridge_owner/repos/$gitpub_sonar_bridge_repo/commits/$gitpub_sonar_bridge_commit_id/comments?path=$gitpub_sonar_bridge_file_path" \

--- a/step.yml
+++ b/step.yml
@@ -38,7 +38,7 @@ inputs:
         The `.xcworkspace` path, relative to
         the Working directory.
       is_expand: true
-      is_required: true
+      is_required: false
   - project: 
     opts:
       title: "Project"
@@ -46,21 +46,21 @@ inputs:
         The `.xcodeproj` path, relative to
         the Working directory.
       is_expand: true
-      is_required: true
+      is_required: false
   - scheme: 
     opts:
       title: "Project Scheme"
       description: |
         The name of the project scheme.
       is_expand: true
-      is_required: true
+      is_required: false
   - binary_basename:
     opts:
       title: "Binary Basename"
       description: |
         The name of the binary.
       is_expand: true
-      is_required: true
+      is_required: false
   - project_repository_url:
     opts:
       title: "Project repository HTTPS URL"


### PR DESCRIPTION
Some of the parameters are now optional in case the devs want to use the config in their .slather.yml file. The output-directory param will have to be fixed since the script for reading the coverage file will have to be known in Jenkins -- where there's another script that actually performs the Sonar operation).